### PR TITLE
Keep rows order

### DIFF
--- a/pghrep/src/main.go
+++ b/pghrep/src/main.go
@@ -24,6 +24,7 @@ import (
     "text/template"
     "sort"
     "strconv"
+    "./orderedmap"
 )
 
 var DEBUG bool = false
@@ -82,12 +83,13 @@ func FileExists(name string) bool {
 // Parse json data from string to map
 // Return map[string]interface{}
 func ParseJson(jsonData string) map[string]interface{} {
-    var data map[string]interface{}
-    if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
+    orderedData := orderedmap.New()
+    if err := json.Unmarshal([]byte(jsonData), &orderedData); err != nil {
         dbg("Can't parse json data:", err)
         return nil
     } else {
-        return data
+        dt := orderedData.ToInterfaceArray()
+        return dt
     }
 }
 
@@ -239,8 +241,10 @@ func determineMasterReplica(data map[string]interface{}) {
         if hostData["role"] == "master" {
             hostRoles["master"] = host
         } else {
-            index, _ := strconv.Atoi(pyraconv.ToString(hostData["index"]))
-            replicas[index] = host
+            if ! strings.HasSuffix(host, "_keys") {
+                index, _ := strconv.Atoi(pyraconv.ToString(hostData["index"]))
+                replicas[index] = host
+            }
         }
     }
     var keys []int
@@ -292,7 +296,7 @@ func main() {
     } else {
         log.Fatal("ERROR: Content given by --checkdata is wrong json content.")
     }
-    
+
     checkId = strings.ToUpper(checkId)
     loadDependencies(resultData)
     determineMasterReplica(resultData)

--- a/pghrep/src/orderedmap/orderedmap.go
+++ b/pghrep/src/orderedmap/orderedmap.go
@@ -1,0 +1,361 @@
+package orderedmap
+
+import (
+    "encoding/json"
+    "errors"
+    "sort"
+    "strings"
+    "reflect"
+)
+
+var NoValueError = errors.New("No value for this key")
+
+type KeyIndex struct {
+    Key   string
+    Index int
+}
+type ByIndex []KeyIndex
+
+func (a ByIndex) Len() int           { return len(a) }
+func (a ByIndex) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByIndex) Less(i, j int) bool { return a[i].Index < a[j].Index }
+
+type Pair struct {
+    key   string
+    value interface{}
+}
+
+func (kv *Pair) Key() string {
+    return kv.key
+}
+
+func (kv *Pair) Value() interface{} {
+    return kv.value
+}
+
+type ByPair struct {
+    Pairs    []*Pair
+    LessFunc func(a *Pair, j *Pair) bool
+}
+
+func (a ByPair) Len() int           { return len(a.Pairs) }
+func (a ByPair) Swap(i, j int)      { a.Pairs[i], a.Pairs[j] = a.Pairs[j], a.Pairs[i] }
+func (a ByPair) Less(i, j int) bool { return a.LessFunc(a.Pairs[i], a.Pairs[j]) }
+
+type OrderedMap struct {
+    keys   []string
+    values map[string]interface{}
+}
+
+func New() *OrderedMap {
+    o := OrderedMap{}
+    o.keys = []string{}
+    o.values = map[string]interface{}{}
+    return &o
+}
+
+func (o *OrderedMap) Get(key string) (interface{}, bool) {
+    val, exists := o.values[key]
+    return val, exists
+}
+
+func (o *OrderedMap) Set(key string, value interface{}) {
+    _, exists := o.values[key]
+    if !exists {
+	o.keys = append(o.keys, key)
+    }
+    o.values[key] = value
+}
+
+func (o *OrderedMap) Delete(key string) {
+    // check key is in use
+    _, ok := o.values[key]
+    if !ok {
+	return
+    }
+    // remove from keys
+    for i, k := range o.keys {
+	if k == key {
+	    o.keys = append(o.keys[:i], o.keys[i+1:]...)
+	    break
+	}
+    }
+    // remove from values
+    delete(o.values, key)
+}
+
+func (o *OrderedMap) Keys() []string {
+    return o.keys
+}
+
+// SortKeys Sort the map keys using your sort func
+func (o *OrderedMap) SortKeys(sortFunc func(keys []string)) {
+    sortFunc(o.keys)
+}
+
+// Sort Sort the map using your sort func
+func (o *OrderedMap) Sort(lessFunc func(a *Pair, b *Pair) bool) {
+    pairs := make([]*Pair, len(o.keys))
+    for i, key := range o.keys {
+	pairs[i] = &Pair{key, o.values[key]}
+    }
+
+    sort.Sort(ByPair{pairs, lessFunc})
+
+    for i, pair := range pairs {
+	o.keys[i] = pair.key
+    }
+}
+
+func (o *OrderedMap) UnmarshalJSON(b []byte) error {
+    if o.values == nil {
+	o.values = map[string]interface{}{}
+    }
+    var err error
+    err = mapStringToOrderedMap(string(b), o)
+    if err != nil {
+	return err
+    }
+    return nil
+}
+
+func mapStringToOrderedMap(s string, o *OrderedMap) error {
+    // parse string into map
+    m := map[string]interface{}{}
+    err := json.Unmarshal([]byte(s), &m)
+    if err != nil {
+	return err
+    }
+    // Get the order of the keys
+    orderedKeys := []KeyIndex{}
+    for k, _ := range m {
+        kEscaped := strings.Replace(k, `"`, `\"`, -1)
+        kEscaped = strings.Replace(kEscaped, "\n", "\\n", -1)
+        kQuoted := `"` + kEscaped + `"`
+        // Find how much content exists before this key.
+        // If all content from this key and after is replaced with a close
+        // brace, it should still form a valid json string.
+        sTrimmed := s
+        for len(sTrimmed) > 0 {
+            lastIndex := strings.LastIndex(sTrimmed, kQuoted)
+            if lastIndex == -1 {
+            break
+            }
+            sTrimmed = sTrimmed[0:lastIndex]
+            sTrimmed = strings.TrimSpace(sTrimmed)
+            if len(sTrimmed) > 0 && sTrimmed[len(sTrimmed)-1] == ',' {
+            sTrimmed = sTrimmed[0 : len(sTrimmed)-1]
+            }
+            maybeValidJson := sTrimmed + "}"
+            testMap := map[string]interface{}{}
+            err := json.Unmarshal([]byte(maybeValidJson), &testMap)
+            if err == nil {
+            // record the position of this key in s
+            ki := KeyIndex{
+                Key:   k,
+                Index: len(sTrimmed),
+            }
+            orderedKeys = append(orderedKeys, ki)
+            // shorten the string to get the next key
+            startOfValueIndex := lastIndex + len(kQuoted)
+            valueStr := s[startOfValueIndex : len(s)-1]
+            valueStr = strings.TrimSpace(valueStr)
+            if len(valueStr) > 0 && valueStr[0] == ':' {
+                valueStr = valueStr[1:len(valueStr)]
+            }
+            valueStr = strings.TrimSpace(valueStr)
+            if valueStr[0] == '{' {
+                //fmt.Println("MAP", kQuoted, valueStr)
+                // if the value for this key is a map
+                // find end of valueStr by removing everything after last }
+                // until it forms valid json
+                hasValidJson := false
+                i := 1
+                for i < len(valueStr) && !hasValidJson {
+                    if valueStr[i] != '}' {
+                        i = i + 1
+                        continue
+                    }
+                    subTestMap := map[string]interface{}{}
+                    testValue := valueStr[0 : i+1]
+                    err = json.Unmarshal([]byte(testValue), &subTestMap)
+                    if err == nil {
+                        hasValidJson = true
+                        valueStr = testValue
+                        break
+                    }
+                    i = i + 1
+                }
+                // convert to orderedmap
+                // this may be recursive it values in the map are also maps
+                if hasValidJson {
+                    newMap := New()
+                    err := mapStringToOrderedMap(valueStr, newMap)
+                    if err != nil {
+                        return err
+                    }
+                    m[k] = *newMap
+                }
+            } else if valueStr[0] == '[' {
+                // if the value for this key is a slice
+                // find end of valueStr by removing everything after last ]
+                // until it forms valid json
+                hasValidJson := false
+                i := 1
+                for i < len(valueStr) && !hasValidJson {
+                    if valueStr[i] != ']' {
+                        i = i + 1
+                        continue
+                    }
+                    subTestSlice := []interface{}{}
+                    testValue := valueStr[0 : i+1]
+                    err = json.Unmarshal([]byte(testValue), &subTestSlice)
+                    if err == nil {
+                        hasValidJson = true
+                        valueStr = testValue
+                        break
+                    }
+                    i = i + 1
+                }
+                // convert to slice with any map items converted to
+                // orderedmaps
+                // this may be recursive if values in the slice are slices
+                if hasValidJson {
+                    var newSlice []interface{}
+                    err := sliceStringToSliceWithOrderedMaps(valueStr, &newSlice)
+                    if err != nil {
+                        return err
+                    }
+                    m[k] = newSlice
+                }
+            } else {
+                o.Set(k, m[k])
+            }
+            break
+            }
+        }
+    }
+    // Sort the keys
+    sort.Sort(ByIndex(orderedKeys))
+    // Convert sorted keys to string slice
+    k := []string{}
+    for _, ki := range orderedKeys {
+	k = append(k, ki.Key)
+    }
+    // Set the OrderedMap values
+    o.values = m
+    o.keys = k
+    return nil
+}
+
+func sliceStringToSliceWithOrderedMaps(valueStr string, newSlice *[]interface{}) error {
+    // if the value for this key is a []interface, convert any map items to an orderedmap.
+    // find end of valueStr by removing everything after last ]
+    // until it forms valid json
+    itemsStr := strings.TrimSpace(valueStr)
+    itemsStr = itemsStr[1 : len(itemsStr)-1]
+    // get next item in the slice
+    itemIndex := 0
+    startItem := 0
+    endItem := 0
+    for endItem <= len(itemsStr) {
+	couldBeItemEnd := false
+	couldBeItemEnd = couldBeItemEnd || endItem == len(itemsStr)
+	couldBeItemEnd = couldBeItemEnd || (endItem < len(itemsStr) && itemsStr[endItem] == ',')
+	if !couldBeItemEnd {
+	    endItem = endItem + 1
+	    continue
+	}
+	// if this substring compiles to json, it's the next item
+	possibleItemStr := strings.TrimSpace(itemsStr[startItem:endItem])
+	var possibleItem interface{}
+	err := json.Unmarshal([]byte(possibleItemStr), &possibleItem)
+	if err != nil {
+	    endItem = endItem + 1
+	    continue
+	}
+	if possibleItemStr[0] == '{' {
+	    // if item is map, convert to orderedmap
+	    oo := New()
+	    err := mapStringToOrderedMap(possibleItemStr, oo)
+	    if err != nil {
+		return err
+	    }
+	    // add new orderedmap item to new slice
+	    slice := *newSlice
+	    slice = append(slice, *oo)
+	    *newSlice = slice
+	} else if possibleItemStr[0] == '[' {
+	    // if item is slice, convert to slice with orderedmaps
+	    var newItem []interface{}
+	    err := sliceStringToSliceWithOrderedMaps(possibleItemStr, &newItem)
+	    if err != nil {
+		return err
+	    }
+	    // replace original slice item with new slice
+	    slice := *newSlice
+	    slice = append(slice, newItem)
+	    *newSlice = slice
+	} else {
+	    // any non-slice and non-map item, just add json parsed item
+	    slice := *newSlice
+	    slice = append(slice, possibleItem)
+	    *newSlice = slice
+	}
+	// remove this item from itemsStr
+	startItem = endItem + 1
+	endItem = endItem + 1
+	itemIndex = itemIndex + 1
+    }
+    return nil
+}
+
+func (o OrderedMap) MarshalJSON() ([]byte, error) {
+    s := "{"
+    for _, k := range o.keys {
+	// add key
+	kEscaped := strings.Replace(k, `"`, `\"`, -1)
+	s = s + `"` + kEscaped + `":`
+	// add value
+	v := o.values[k]
+	vBytes, err := json.Marshal(v)
+	if err != nil {
+	    return []byte{}, err
+	}
+	s = s + string(vBytes) + ","
+    }
+    if len(o.keys) > 0 {
+	s = s[0 : len(s)-1]
+    }
+    s = s + "}"
+    return []byte(s), nil
+}
+
+func ProcessInterfaceArray(om OrderedMap, data []interface{}) []interface{} {
+    var array []interface{}
+    for key, value := range data {
+        if reflect.TypeOf(value) == reflect.TypeOf(om) {
+            data[key] = (value.(OrderedMap)).ToInterfaceArray()
+        } else if (reflect.TypeOf(value) == reflect.TypeOf(array)) {
+            data[key] = ProcessInterfaceArray(om, value.([]interface{}))
+        }
+    }
+    return data
+}
+
+func (o OrderedMap) ToInterfaceArray() map[string]interface{} {
+    var array []interface{}
+    data := make(map[string]interface{})
+    for _, k := range o.keys {
+        value, _ := o.Get(k)
+        if reflect.TypeOf(value) == reflect.TypeOf(o) {
+            data[k] = (value.(OrderedMap)).ToInterfaceArray()
+            data[k + "_keys"] = (value.(OrderedMap)).keys
+        } else if (reflect.TypeOf(value) == reflect.TypeOf(array)) {
+            data[k] = ProcessInterfaceArray(o, value.([]interface{})) //.(OrderedMap).values
+        }  else {
+            data[k] = value
+        }
+    }
+    return data
+}

--- a/pghrep/templates/A003.tpl
+++ b/pghrep/templates/A003.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
 Setting | Value | Unit
 --------|-------|------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}) | {{ $value.setting}} | {{ if $value.unit }}{{ $value.unit }} {{ end }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index $.results $.hosts.master) "data") $key) }} | {{ $value.setting}} | {{ if $value.unit }}{{ $value.unit }} {{ end }}
 {{ end }}
 
 {{ if gt (len .hosts.replicas) 0 }}
@@ -15,7 +15,7 @@ Setting | Value | Unit
     {{ if (index $.results $host) }}
 Setting | Value | Unit
 --------|-------|------
-{{ range $key, $value := (index (index $.results $host) "data") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}) | {{ $value.setting}} | {{ if $value.unit }}{{ $value.unit }} {{ end }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index $.results $host) "data") $key) }} | {{ $value.setting}} | {{ if $value.unit }}{{ $value.unit }} {{ end }}
 {{ end }}
     {{ else }}
 No data

--- a/pghrep/templates/A004.tpl
+++ b/pghrep/templates/A004.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
  Indicator | Value
 -----------|-------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }}{{ $key }} | {{ Nobr (index $value "value") }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }}{{ $key }}{{ $value := (index (index (index $.results $.hosts.master) "data") $key) }} | {{ Nobr (index $value "value") }}
 {{ end }}
 
 {{ if gt (len .hosts.replicas) 0 }}
@@ -15,7 +15,7 @@
     {{ if (index $.results $host) }}
  Indicator | Value
 -----------|-------
-{{ range $key, $value := (index (index $.results $host) "data") }}{{ $key }} | {{ Nobr (index $value "value") }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }}{{ $key }}{{ $value := (index (index (index $.results $host) "data") $key) }} | {{ Nobr (index $value "value") }}
 {{ end }}
     {{ else }}
       No data

--- a/pghrep/templates/A005.tpl
+++ b/pghrep/templates/A005.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
 Extension name | Installed version | Default version | Is old 
 ---------------|-------------------|-----------------|--------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }} {{ $key }} | {{ $value.installed_version }} | {{ $value.default_version }} | {{ $value.is_old }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }} {{ $key }}{{ $value := (index (index (index $.results $.hosts.master) "data") $key) }} | {{ $value.installed_version }} | {{ $value.default_version }} | {{ $value.is_old }}
 {{ end }}
 
 {{ if gt (len .hosts.replicas) 9999 }}
@@ -15,7 +15,7 @@ Extension name | Installed version | Default version | Is old
     {{ if (index $.results $host) }}
 Extension name | Installed version | Default version | Is old 
 ---------------|-------------------|-----------------|--------
-{{ range $key, $value := (index (index $.results $host) "data") }} {{ $key }} | {{ $value.installed_version }} | {{ $value.default_version }} | {{ $value.is_old }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }} {{ $key }}{{ $value := (index (index (index $.results $host) "data") $key) }} | {{ $value.installed_version }} | {{ $value.default_version }} | {{ $value.is_old }}
 {{ end }}
 {{ else }}No data{{ end}}{{ end }}{{ end }}
 

--- a/pghrep/templates/A007.tpl
+++ b/pghrep/templates/A007.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
 Source | Settings count | Changed settings
 -------|----------------|-----------------
-{{ range $key, $value := (index (index (index .results .hosts.master) "data") "changes") }}{{ if $value.sourcefile }}{{ $value.sourcefile }}{{ else}}DEFAULT{{ end }} | {{ $value.count }} | {{ if $value.examples}} {{ if (gt (len $value.examples) 0) }}{{ range $skey, $sname := (index $value "examples") }}{{ $sname }} {{ end }} {{ end }}
+{{ range $key, $value := (index (index (index .results .hosts.master) "data") "changes") }}{{ if $value.sourcefile }}{{ $value.sourcefile }}{{ else}}default{{ end }} | {{ $value.count }} | {{ if $value.examples}} {{ if (gt (len $value.examples) 0) }}{{ range $skey, $sname := (index $value "examples") }}{{ $sname }} {{ end }} {{ end }}
 {{ end }}{{ end }}
 
 {{ if gt (len .hosts.replicas) 0 }}
@@ -15,7 +15,7 @@ Source | Settings count | Changed settings
     {{ if (index $.results $host) }}
 Source | Settings count | Changed settings
 -------|----------------|-----------------
-{{ range $key, $value := (index (index (index $.results $host) "data") "changes") }}{{ if $value.sourcefile }}{{ $value.sourcefile }}{{ else}}DEFAULT{{ end }} | {{ $value.count }} | {{ if $value.examples}} {{ if (gt (len $value.examples) 0) }}{{ range $skey, $sname := (index $value "examples") }}{{ $sname }} {{ end }} {{ end }}
+{{ range $key, $value := (index (index (index $.results $host) "data") "changes") }}{{ if $value.sourcefile }}{{ $value.sourcefile }}{{ else}}default{{ end }} | {{ $value.count }} | {{ if $value.examples}} {{ if (gt (len $value.examples) 0) }}{{ range $skey, $sname := (index $value "examples") }}{{ $sname }} {{ end }} {{ end }}
 {{ end }}{{ end }}
     {{ else }}
 No data

--- a/pghrep/templates/D004.tpl
+++ b/pghrep/templates/D004.tpl
@@ -7,15 +7,18 @@
 #### `pg_stat_statements` extension settings ####
 Setting | Value | Unit | Type | Min value | Max value
 --------|-------|------|------|-----------|-----------
-{{ range $setting_name, $setting_data := (index (index (index .results .hosts.master) "data") "pg_stat_statements") }}[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}Min value: {{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}Max value: {{ $setting_data.max_val }} {{ end }}
+{{ range $i, $setting_name := (index (index (index .results .hosts.master) "data") "pg_stat_statements_keys") }}
+{{- $setting_data := (index (index (index (index $.results $.hosts.master) "data") "pg_stat_statements") $setting_name) -}}
+[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}{{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}{{ $setting_data.max_val }} {{ end }}
 {{ end }}
 
 #### `kcache` extension settings ####
 Setting | Value | Unit | Type | Min value | Max value
 --------|-------|------|------|-----------|-----------
-{{ range $setting_name, $setting_data := (index (index (index .results .hosts.master) "data") "kcache") }}[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}Min value: {{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}Max value: {{ $setting_data.max_val }} {{ end }}
+{{ range $i, $setting_name := (index (index (index .results .hosts.master) "data") "kcache_keys") }}
+{{- $setting_data := (index (index (index (index $.results $.hosts.master) "data") "kcache") $setting_name) -}}
+[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}{{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}{{ $setting_data.max_val }} {{ end }}
 {{ end }}
-
 
 {{ if gt (len .hosts.replicas) 0 }}
 ### Replica servers: ###
@@ -25,15 +28,21 @@ Setting | Value | Unit | Type | Min value | Max value
 #### `pg_stat_statements` settings ####
 Setting | Value | Unit | Type | Min value | Max value
 --------|-------|------|------|-----------|-----------
-{{ range $setting_name, $setting_data := (index (index (index $.results $host) "data") "pg_stat_statements") }}[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}Min value: {{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}Max value: {{ $setting_data.max_val }} {{ end }}
+{{ range $i, $setting_name := (index (index (index $.results $host) "data") "pg_stat_statements_keys") }}
+{{- $setting_data := (index (index (index (index $.results $host) "data") "pg_stat_statements") $setting_name) -}}
+[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}{{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}{{ $setting_data.max_val }} {{ end }}
 {{ end }}
 
 #### `kcache` settings ####
 Setting | Value | Unit | Type | Min value | Max value
 --------|-------|------|------|-----------|-----------
-{{ range $setting_name, $setting_data := (index (index (index $.results $host) "data") "kcache") }}[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}Min value: {{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}Max value: {{ $setting_data.max_val }} {{ end }}
-{{ end }}
-{{ end }}{{ end }}{{ end }}
+{{ range $i, $setting_name := (index (index (index $.results $host) "data") "kcache_keys") }}
+{{- $setting_data := (index (index (index (index $.results $host) "data") "kcache") $setting_name) -}}
+[{{ $setting_name }}](https://postgresqlco.nf/en/doc/param/{{ $setting_name }})|{{ $setting_data.setting }}|{{ if $setting_data.unit }}{{ $setting_data.unit }} {{ end }}|{{ $setting_data.vartype }}|{{ if $setting_data.min_val }}{{ $setting_data.min_val }} {{ end }}|{{ if $setting_data.max_val }}{{ $setting_data.max_val }} {{ end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 ## Conclusions ##
 

--- a/pghrep/templates/F001.tpl
+++ b/pghrep/templates/F001.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
  Table | Size | Extra | Bloat | Live | Last vacuum
 -------|------|-------|-------|------|-------------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }}{{ $key }} | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ if (index $value "Last Vaccuum") }} {{ ( index $value "Last Vaccuum") }} {{ end }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }}{{ $key }}{{ $value := (index (index (index $.results $.hosts.master) "data") $key) }} | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ if (index $value "Last Vaccuum") }} {{ ( index $value "Last Vaccuum") }} {{ end }}
 {{ end }}
 
 {{ if gt (len .hosts.replicas) 0 }}
@@ -15,7 +15,7 @@
     {{ if (index $.results $host) }}
  Table | Size | Extra | Bloat | Live | Last vacuum
 -------|------|-------|-------|------|-------------
-{{ range $key, $value := (index (index $.results $host) "data") }}{{ $key }} | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ if (index $value "Last Vaccuum") }} {{ ( index $value "Last Vaccuum") }} {{ end }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }}{{ $key }}{{ $value := (index (index (index $.results $host) "data") $key) }} | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ if (index $value "Last Vaccuum") }} {{ ( index $value "Last Vaccuum") }} {{ end }}
 {{ end }}
 {{ else }}
 No data

--- a/pghrep/templates/F002.tpl
+++ b/pghrep/templates/F002.tpl
@@ -5,7 +5,7 @@
 ### Master (`{{.hosts.master}}`) ###
  Index (Table) | Size | Extra | Bloat | Live | Fill factor
 ---------------|------|-------|-------|------|-------------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }} {{ $tableIndex := Split $key "\n" }} {{ $table := Trim (index $tableIndex 1) " ()"}}{{ (index $tableIndex 0) }} ({{ $table }}) | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ ( index $value "fillfactor") }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }} {{ $tableIndex := Split $key "\n" }} {{ $table := Trim (index $tableIndex 1) " ()"}}{{ (index $tableIndex 0) }} ({{ $table }}){{ $value := (index (index (index $.results $.hosts.master) "data") $key) }} | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ ( index $value "fillfactor") }}
 {{ end }}
 
 {{ if gt (len .hosts.replicas) 0 }}
@@ -15,7 +15,7 @@
     {{ if (index $.results $host) }}
  Index (Table) | Size | Extra | Bloat | Live | Fill factor
 ---------------|------|-------|-------|------|-------------
-{{ range $key, $value := (index (index $.results $host) "data") }} {{ $tableIndex := Split $key "\n" }} {{ $table := Trim (index $tableIndex 1) " ()"}}{{ (index $tableIndex 0) }} ({{ $table }}) | {{ ( index $value "Size") }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ ( index $value "fillfactor") }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }} {{ $tableIndex := Split $key "\n" }} {{ $table := Trim (index $tableIndex 1) " ()"}}{{ (index $tableIndex 0) }} ({{ $table }}) {{ $value := (index (index (index $.results $host) "data") $key) }}| {{ ( index $value "Size") }}{{ $value := (index (index (index $.results $host) "data") $key) }} | {{ ( index $value "Extra") }} | {{ ( index $value "Bloat") }} | {{ ( index $value "Live") }} | {{ ( index $value "fillfactor") }}
 {{ end }}
 {{ else }}
 No data

--- a/pghrep/templates/F003.tpl
+++ b/pghrep/templates/F003.tpl
@@ -5,7 +5,9 @@
 ### Master (`{{.hosts.master}}`) ###
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index .results .hosts.master) "data") "settings") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index .results .hosts.master) "data") "settings_keys") }}
+{{- $value := (index (index (index (index $.results $.hosts.master) "data") "settings") $key) -}}
+[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting }}|{{ $value.unit }}
 {{ end }}
 {{ if (index (index .results .hosts.master) "data").iotop }}
 #### iotop information ####
@@ -25,7 +27,9 @@ Result:
 
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index $.results $host) "data") "settings") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index $.results $host) "data") "settings_keys") }}
+{{- $value := (index (index (index (index $.results $host) "data") "settings") $key) -}}
+[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
 {{ end }}
 {{ if (index (index $.results $host) "data").iotop }}
 #### iotop information ####

--- a/pghrep/templates/G001.tpl
+++ b/pghrep/templates/G001.tpl
@@ -6,19 +6,27 @@
 
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index .results .hosts.master) "data") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
-{{ end }}
+{{ range $i, $key := (index (index .results .hosts.master) "data_keys") }}
+    {{- $value := (index (index (index $.results $.hosts.master) "data") $key) -}}
+    [{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ end -}}
+
 {{ if gt (len .hosts.replicas) 0 }}
 ### Replica servers: ###
-  {{ range $skey, $host := .hosts.replicas }}
+    {{ range $skey, $host := .hosts.replicas }}
 #### Replica (`{{ $host }}`) ####
-    {{ if (index $.results $host) }}
+        {{ if (index $.results $host) }}
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index $.results $host) "data") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
-{{ end }}{{ else }}
-No data
-{{ end}}{{ end }}{{ end }}
+{{ range $i, $key := (index (index $.results $host) "data_keys") }}
+    {{- $value := (index (index (index $.results $host) "data") $key) -}}
+    [{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ end }}
+        {{- else -}}
+            No data
+        {{- end -}}
+    {{- end -}}
+{{- end }}
 
 ## Conclusions ##
 

--- a/pghrep/templates/G003.tpl
+++ b/pghrep/templates/G003.tpl
@@ -7,17 +7,17 @@
 #### Timeouts ####
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index .results .hosts.master) "data") "timeouts") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index .results .hosts.master) "data") "timeouts_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index (index $.results $.hosts.master) "data") "timeouts") $key)}}|{{ $value.setting}}|{{ $value.unit }}
 {{ end }}
 #### Locks ####
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index .results .hosts.master) "data") "locks") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index .results .hosts.master) "data") "locks_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index (index $.results $.hosts.master) "data") "locks") $key) }}|{{ $value.setting}}|{{ $value.unit }}
 {{ end }}
 #### Databases data ####
 Database | Conflicts | Deadlocks | Stats reset at | Stat reset
 -------------|-------|-----------|----------------|------------
-{{ range $key, $value := (index (index (index .results .hosts.master) "data") "databases_stat") }}{{$key}}|{{ $value.conflicts}}|{{ $value.deadlocks }}|{{ $value.stats_reset }}|{{ $value.stats_reset_age }}
+{{ range $i, $key := (index (index (index .results .hosts.master) "data") "databases_stat_keys") }}{{$key}}{{ $value:= (index (index (index (index $.results $.hosts.master) "data") "databases_stat") $key) }}|{{ $value.conflicts}}|{{ $value.deadlocks }}|{{ $value.stats_reset }}|{{ $value.stats_reset_age }}
 {{ end }}
 {{ if gt (len .hosts.replicas) 0 }}
 ### Replica servers: ###
@@ -27,17 +27,17 @@ Database | Conflicts | Deadlocks | Stats reset at | Stat reset
 #### Timeouts ####
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index $.results $host) "data") "timeouts") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index $.results $host) "data") "timeouts_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index (index $.results $host) "data") "timeouts") $key)}}|{{ $value.setting}}|{{ $value.unit }}
 {{ end }}
 #### Locks ####
 Setting name | Value | Unit
 -------------|-------|------
-{{ range $key, $value := (index (index (index $.results $host) "data") "locks") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }})|{{ $value.setting}}|{{ $value.unit }}
+{{ range $i, $key := (index (index (index $.results $host) "data") "locks_keys") }}[{{ $key }}](https://postgresqlco.nf/en/doc/param/{{ $key }}){{ $value := (index (index (index (index $.results $host) "data") "locks") $key)}}|{{ $value.setting}}|{{ $value.unit }}
 {{ end }}
 #### Databases data ####
 Database | Conflicts | Deadlocks | Stats reset at | Stat reset
 -------------|-------|-----------|----------------|------------
-{{ range $key, $value := (index (index (index $.results $host) "data") "databases_stat") }}{{$key}}|{{ $value.conflicts}}|{{ $value.deadlocks }}|{{ $value.stats_reset }}|{{ $value.stats_reset_age }}
+{{ range $i, $key := (index (index (index $.results $host) "data") "databases_stat_keys") }}{{$key}}{{ $value:= (index (index (index (index $.results $host) "data") "databases_stat") $key) }}|{{ $value.conflicts}}|{{ $value.deadlocks }}|{{ $value.stats_reset }}|{{ $value.stats_reset_age }}
 {{ end }}
 {{ else }}
 No data

--- a/pghrep/templates/H001.tpl
+++ b/pghrep/templates/H001.tpl
@@ -8,7 +8,7 @@
 
 Index name | Reason | Scheme name | Table name | Index size | Table size
 -----------|--------|-------------|------------|------------|------------
-{{ range $index_name, $index_data := (index (index (index .results .hosts.master) "data") "indexes") }}{{ $index_name }} | {{ $index_data.reason }} | {{ $index_data.schemaname }} | {{ $index_data.tablename }} | {{ $index_data.index_size }} | {{ $index_data.table_size }}
+{{ range $i, $index_name := (index (index (index .results .hosts.master) "data") "indexes_keys") }}{{ $index_name }}{{ $index_data := (index (index (index (index $.results $.hosts.master) "data") "indexes") $index_name) }} | {{ $index_data.reason }} | {{ $index_data.schemaname }} | {{ $index_data.tablename }} | {{ $index_data.index_size }} | {{ $index_data.table_size }}
 {{ end }}
 
 #### Drop code ####
@@ -32,7 +32,7 @@ Index name | Reason | Scheme name | Table name | Index size | Table size
 
 Index name | Reason | Scheme name | Table name | Index size | Table size
 -----------|--------|-------------|------------|------------|------------
-{{ range $index_name, $index_data := (index (index (index $.results $host) "data") "indexes") }}{{ $index_name }} | {{ $index_data.reason }} | {{ $index_data.schemaname }} | {{ $index_data.tablename }} | {{ $index_data.index_size }} | {{ $index_data.table_size }}
+{{ range $i, $index_name := (index (index (index $.results $host) "data") "indexes_keys") }}{{ $index_name }}{{ $index_data := (index (index (index (index $.results $host) "data") "indexes") $index_name) }} | {{ $index_data.reason }} | {{ $index_data.schemaname }} | {{ $index_data.tablename }} | {{ $index_data.index_size }} | {{ $index_data.table_size }}
 {{ end }}
 
 #### Drop code ####


### PR DESCRIPTION
Keep rows order in reports implemented with OrderedMap library. Some MD templated reworked. and some still can be improved.